### PR TITLE
Implement tab looping

### DIFF
--- a/src/main/java/com/kqp/inventorytabs/tabs/TabManager.java
+++ b/src/main/java/com/kqp/inventorytabs/tabs/TabManager.java
@@ -137,11 +137,15 @@ public class TabManager {
                     GLFW.GLFW_KEY_LEFT_SHIFT)) {
                 if (currentTabIndex > 0) {
                     onTabClick(tabs.get(currentTabIndex - 1));
+                } else {
+                    onTabClick(tabs.get(tabs.size() - 1));
                 }
                 return true;
             } else {
                 if (currentTabIndex < tabs.size() - 1) {
                     onTabClick(tabs.get(currentTabIndex + 1));
+                } else {
+                    onTabClick(tabs.get(0));
                 }
 
                 return true;
@@ -254,3 +258,4 @@ public class TabManager {
                 .play(PositionedSoundInstance.master(SoundEvents.UI_BUTTON_CLICK, 1.0F));
     }
 }
+


### PR DESCRIPTION
In this mod, tab and shift-tab jump the selected tab forwards and backwards, respectively.

Previously, when you hit tab at the end of the list, or hit shift-tab at the beginning of the list, nothing would happen.

This pull request allows hitting tab at the end of the list to loop to the beginning of the list, and hitting shift-tab at the beginning to loop to the end.