### PR TITLE
Update to 1.18.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,39 @@
+# Automatically build the project and run any configured tests for every push
+# and submitted pull request. This can help catch issues that only occur on
+# certain platforms or Java versions, and provides a first line of defence
+# against bad commits.
+
+name: build
+on: [pull_request, push]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        # Use these Java versions
+        java: [
+          16    # Minimum supported by Minecraft
+        ]
+        # and run on both Linux and Windows
+        os: [ubuntu-20.04, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v2
+      - name: validate gradle wrapper
+        uses: gradle/wrapper-validation-action@v1
+      - name: setup jdk ${{ matrix.java }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      - name: make gradle wrapper executable
+        if: ${{ runner.os != 'Windows' }}
+        run: chmod +x ./gradlew
+      - name: build
+        run: ./gradlew build
+      - name: capture build artifacts
+        if: ${{ runner.os == 'Linux' && matrix.java == '16' }} # Only upload artifacts built from latest java on one OS
+        uses: actions/upload-artifact@v2
+        with:
+          name: Artifacts
+          path: build/libs/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
       - name: build
         run: ./gradlew build
       - name: capture build artifacts
-        if: ${{ runner.os == 'Linux' && matrix.java == '16' }} # Only upload artifacts built from latest java on one OS
+        if: ${{ runner.os == 'Linux' && matrix.java == '17' }} # Only upload artifacts built from latest java on one OS
         uses: actions/upload-artifact@v2
         with:
           name: Artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,8 +12,7 @@ jobs:
       matrix:
         # Use these Java versions
         java: [
-          16,    # Minimum supported by Minecraft
-          17,    # Current Java LTS
+          17    # Minimum supported by Minecraft
         ]
         # and run on both Linux and Windows
         os: [ubuntu-20.04, windows-latest]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,8 @@ jobs:
       matrix:
         # Use these Java versions
         java: [
-          16    # Minimum supported by Minecraft
+          16,    # Minimum supported by Minecraft
+          17,    # Current Java LTS
         ]
         # and run on both Linux and Windows
         os: [ubuntu-20.04, windows-latest]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # InventoryTabs
-Adds tabs to access nearby blocks.
+Adds tabs to access nearby blocks. Requires Cloth Config API.
 
 ## Devs
 ### Importing

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.8-SNAPSHOT'
+	id 'fabric-loom' version '0.10-SNAPSHOT'
 	id 'maven-publish'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,10 @@ jar {
 	}
 }
 
+loom {
+	accessWidenerPath = file("src/main/resources/inventorytabs.accesswidener")
+}
+
 // configure the maven publication
 publishing {
 	publications {

--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,8 @@ plugins {
 	id 'maven-publish'
 }
 
-sourceCompatibility = JavaVersion.VERSION_16
-targetCompatibility = JavaVersion.VERSION_16
+sourceCompatibility = JavaVersion.VERSION_17
+targetCompatibility = JavaVersion.VERSION_17
 
 archivesBaseName = project.archives_base_name
 version = "${project.mod_version}-${project.minecraft_version}"
@@ -47,8 +47,8 @@ tasks.withType(JavaCompile).configureEach {
 	// If Javadoc is generated, this must be specified in that task too.
 	it.options.encoding = "UTF-8"
 
-	// Minecraft 1.17 (21w19a) upwards uses Java 16.
-	it.options.release = 16
+	// Minecraft 1.18 (1.18-pre2) upwards uses Java 17.
+	it.options.release = 17
 }
 
 java {
@@ -68,13 +68,7 @@ jar {
 publishing {
 	publications {
 		mavenJava(MavenPublication) {
-			// add all the jars that should be included when publishing to maven
-			artifact(remapJar) {
-				builtBy remapJar
-			}
-			artifact(sourcesJar) {
-				builtBy remapSourcesJar
-			}
+			from components.java
 		}
 	}
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,15 +3,15 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/versions.html
-	minecraft_version=1.17.1
-	yarn_mappings=1.17.1+build.13
-	loader_version=0.11.6
+	minecraft_version=1.18.1
+	yarn_mappings=1.18.1+build.3
+	loader_version=0.12.11
 
 # Mod Properties
-	mod_version = 0.4.1
+	mod_version = 0.4.2
 	maven_group = com.kqp
 	archives_base_name = inventorytabs
 
 # Dependencies
-	fabric_version=0.37.0+1.17
-	clothconfig_version=5.0.34
+	fabric_version=0.44.0+1.18
+	clothconfig_version=6.1.48

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,10 +1,10 @@
 pluginManagement {
     repositories {
-        jcenter()
         maven {
             name = 'Fabric'
             url = 'https://maven.fabricmc.net/'
         }
+        mavenCentral()
         gradlePluginPortal()
     }
 }

--- a/src/main/java/com/kqp/inventorytabs/tabs/tab/SimpleBlockTab.java
+++ b/src/main/java/com/kqp/inventorytabs/tabs/tab/SimpleBlockTab.java
@@ -86,7 +86,7 @@ public class SimpleBlockTab extends Tab {
 
         if (blockEntity != null) {
             NbtCompound tag = new NbtCompound();
-            // blockEntity.writeNbt(tag); // temporarily removing this because writeNBT was changed to protected
+            blockEntity.writeNbt(tag); // had to use an accesswidener for this in 1.18
 
             if (tag.contains("CustomName", 8)) {
                 return Text.Serializer.fromJson(tag.getString("CustomName"));

--- a/src/main/java/com/kqp/inventorytabs/tabs/tab/SimpleBlockTab.java
+++ b/src/main/java/com/kqp/inventorytabs/tabs/tab/SimpleBlockTab.java
@@ -86,7 +86,7 @@ public class SimpleBlockTab extends Tab {
 
         if (blockEntity != null) {
             NbtCompound tag = new NbtCompound();
-            blockEntity.writeNbt(tag);
+            blockEntity.writeNbt(tag); // temporarily removing this because writeNBT was changed to protected
 
             if (tag.contains("CustomName", 8)) {
                 return Text.Serializer.fromJson(tag.getString("CustomName"));

--- a/src/main/java/com/kqp/inventorytabs/tabs/tab/SimpleBlockTab.java
+++ b/src/main/java/com/kqp/inventorytabs/tabs/tab/SimpleBlockTab.java
@@ -86,7 +86,7 @@ public class SimpleBlockTab extends Tab {
 
         if (blockEntity != null) {
             NbtCompound tag = new NbtCompound();
-            blockEntity.writeNbt(tag); // temporarily removing this because writeNBT was changed to protected
+            // blockEntity.writeNbt(tag); // temporarily removing this because writeNBT was changed to protected
 
             if (tag.contains("CustomName", 8)) {
                 return Text.Serializer.fromJson(tag.getString("CustomName"));

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -28,6 +28,7 @@
   "mixins": [
     "inventorytabs.mixins.json"
   ],
+  "accessWidener": "inventorytabs.accesswidener",
   "depends": {
     "fabricloader": ">=0.11.6",
     "fabric": ">=0.37.0",

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -5,7 +5,9 @@
   "name": "Inventory Tabs",
   "description": "Adds tabs to your inventory that lead to nearby blocks.",
   "authors": [
-    "KQP"
+    "KQP",
+    "LiamMCW",
+    "Andrew6rant (Andrew Grant)"
   ],
   "contact": {
     "homepage": "https://github.com/LiamMCW/inventorytabs",
@@ -29,6 +31,6 @@
   "depends": {
     "fabricloader": ">=0.11.6",
     "fabric": ">=0.37.0",
-    "minecraft": "1.17.1"
+    "minecraft": "1.18.x"
   }
 }

--- a/src/main/resources/inventorytabs.accesswidener
+++ b/src/main/resources/inventorytabs.accesswidener
@@ -1,0 +1,2 @@
+accessWidener	v1	named
+accessible    method    net/minecraft/block/entity/BlockEntity    writeNbt    (Lnet/minecraft/nbt/NbtCompound;)V


### PR DESCRIPTION
Github doesn't allow pull requests to open a new branch, so I pointed this at 1.17.1 for now.

I also created an accesswidener for BlockEntity#writeNbt since it changed in 1.18. I'm not sure if it is the best practice though. You can grab the previous commit without it if you'd like. Everything works the same except named inventories don't get a custom named tooltip